### PR TITLE
Fix: Add nil check to checkAddressConflict method

### DIFF
--- a/parallel/parallel_evm.go
+++ b/parallel/parallel_evm.go
@@ -116,18 +116,29 @@ func (k *ParallelEVM) SplitTxnCtxList(list []*txnCtx) [][]*txnCtx {
 
 func checkAddressConflict(curTxn *txnCtx, curList []*txnCtx) bool {
 	for _, compare := range curList {
-		if *compare.req.Address == *curTxn.req.Address {
-			return true
+
+		if curTxn.req.Address != nil && compare.req.Address != nil {
+			if *compare.req.Address == *curTxn.req.Address {
+				return true
+			}
 		}
-		if *compare.req.Address == curTxn.req.Origin {
-			return true
+
+		if compare.req.Address != nil {
+			if *compare.req.Address == curTxn.req.Origin {
+				return true
+			}
 		}
-		if compare.req.Origin == *curTxn.req.Address {
-			return true
+
+		if curTxn.req.Address != nil {
+			if compare.req.Origin == *curTxn.req.Address {
+				return true
+			}
 		}
+
 		if compare.req.Origin == curTxn.req.Origin {
 			return true
 		}
+
 	}
 	return false
 }


### PR DESCRIPTION
Fix: Add nil check to checkAddressConflict method to handle zero address in contract transactions