### PR TITLE
fix: Handle null receipt in eth_getTransactionByHash to prevent null pointer exception(issue #158)

### DIFF
--- a/evm/ethrpc/api_backend.go
+++ b/evm/ethrpc/api_backend.go
@@ -422,6 +422,9 @@ func (e *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 	if err != nil {
 		return false, nil, common.Hash{}, 0, 0, err
 	}
+	if receipt == nil {
+		return false, nil, common.Hash{}, 0, 0, nil
+	}
 
 	//resp, err := e.adaptChainRead(rcptReq, "GetReceipt")
 	//if err != nil {
@@ -436,7 +439,6 @@ func (e *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 	blockHash := receipt.BlockHash
 	blockNumber := receipt.Height
 	var index uint64
-
 	if receipt.Extra != nil {
 		ethRcpt := new(types.Receipt)
 		err = json.Unmarshal(receipt.Extra, ethRcpt)
@@ -446,7 +448,7 @@ func (e *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 		}
 		index = uint64(ethRcpt.TransactionIndex)
 	}
-	
+
 	return true, ethTxn, common.Hash(blockHash), uint64(blockNumber), index, nil
 }
 


### PR DESCRIPTION
close #158 

Here are the steps for deploying a contract using Hardhat:
eth_estimateGas ------------> Estimate the gas required for deploying the contract
eth_gasPrice ------------> Get the current gas price
eth_sendRawTransaction ------> Send the signed transaction
eth_getTransactionByHash <-- Poll to get the transaction receipt

Currently, our L2 RPC, when calling the eth_getTransactionByHash method, results in a null pointer exception if the receipt does not exist (previous logic also had issues, as it would directly return an exception in the result). This causes an error during polling when an exception is caught. However, this is a normal situation because it takes time for the transaction to be processed on-chain, and it might not be found.