### PR TITLE
fix agreement error in transaction check logic

### DIFF
--- a/evm/errors.go
+++ b/evm/errors.go
@@ -11,7 +11,7 @@ import (
 
 // From geth/core/txpool/errors
 var (
-	// ErrAlreadyKnown is returned if the transactions is already contained
+	// ErrAlreadyKnown is returned if the transaction is already contained
 	// within the pool.
 	ErrAlreadyKnown = errors.New("already known")
 


### PR DESCRIPTION
In the current implementation, there is a minor grammatical issue in the condition where we check if a transaction is already present. The phrase "if the transactions is already contained" was used, but it should be corrected to "if the transaction is already contained" to ensure proper subject-verb agreement. 

I’ve fixed this small error and updated the code accordingly.
The logic remains the same, but the wording now correctly reflects the singular form of "transaction."
