### PR TITLE
fix spelling issues 

### DIFF
--- a/evm/eth.go
+++ b/evm/eth.go
@@ -507,7 +507,7 @@ func (s *Solidity) executeContractCall(ctx *context.WriteContext, txReq *TxReque
 		return 0, err
 	}
 
-	// logrus.Printf("[Execute Txn] SendTx success. Oringin code = %v, Hex Code = %v, Left Gas = %v", code, hex.EncodeToString(code), leftOverGas)
+	// logrus.Printf("[Execute Txn] SendTx success. Origin code = %v, Hex Code = %v, Left Gas = %v", code, hex.EncodeToString(code), leftOverGas)
 	return txReq.GasLimit - leftOverGas, emitReceipt(ctx, vmenv, txReq, code, common.Address{}, leftOverGas, err)
 }
 

--- a/parallel/evm_util.go
+++ b/parallel/evm_util.go
@@ -210,13 +210,13 @@ func (k *ParallelEVM) checkNonce(sdb *state.StateDB, tctx *txnCtx) {
 		diff := new(big.Int).Sub(currentMessageNonceSlot, lastMessageNonceSlot)
 		if !bridge {
 			if diff.Cmp(big.NewInt(0)) != 0 {
-				logrus.Warnf("message nonce slot changed: txhash %s, before %s, after %s, diff %s,tctx.ctx.Block.Height %d", tctx.txn.TxnHash.String(), lastMessageNonceSlot.String(), currentMessageNonceSlot.String(), diff.String(), tctx.ctx.Block.Height)
+				logrus.Warnf("message nonce slot changed: txhash %s, before %s, after %s, diff %s, tctx.ctx.Block.Height %d", tctx.txn.TxnHash.String(), lastMessageNonceSlot.String(), currentMessageNonceSlot.String(), diff.String(), tctx.ctx.Block.Height)
 				metrics.WithdrawMessageNonceGap.WithLabelValues(typ, "changed").Inc()
 			}
 		}
 		if bridge {
 			if diff.Cmp(big.NewInt(1)) > 0 {
-				logrus.Warnf("message nonce slot increased by more than 1: txhash %s, before %s, after %s, diff %s,tctx.ctx.Block.Height %d", tctx.txn.TxnHash.String(), lastMessageNonceSlot.String(), currentMessageNonceSlot.String(), diff.String(), tctx.ctx.Block.Height)
+				logrus.Warnf("message nonce slot increased by more than 1: txhash %s, before %s, after %s, diff %s, tctx.ctx.Block.Height %d", tctx.txn.TxnHash.String(), lastMessageNonceSlot.String(), currentMessageNonceSlot.String(), diff.String(), tctx.ctx.Block.Height)
 				metrics.WithdrawMessageNonceGap.WithLabelValues(typ, "more_increase").Inc()
 			}
 			lastMessageNonceSlot.Set(currentMessageNonceSlot)

--- a/parallel/parallel_evm.go
+++ b/parallel/parallel_evm.go
@@ -131,9 +131,9 @@ func (e *ParallelEvmExecutor) executeTxnCtxListInConcurrency(list []*txnCtx) []*
 		}(i, c, copiedStateDBList[i])
 	}
 	wg.Wait()
-	curtCtx := pending_state.NewStateContext(false)
+	curCtx := pending_state.NewStateContext(false)
 	for _, tctx := range list {
-		if curtCtx.IsConflict(tctx.ps.GetCtx()) {
+		if curCtx.IsConflict(tctx.ps.GetCtx()) {
 			conflict = true
 			e.k.statManager.ConflictCount++
 			break


### PR DESCRIPTION
evm/eth.go
Oringin - Origin `fix typo`
 
parallel/evm_util.go
%s, tctx.ctx.Block.Height x2 - `add missing space`

parallel/parallel_evm.go
curtCtx - curCtx x2 - `fix function`