### PR TITLE
fix typo Update cross_message.go

### DIFF
--- a/bridge/orm/cross_message.go
+++ b/bridge/orm/cross_message.go
@@ -258,7 +258,7 @@ func (c *CrossMessage) UpdateL1Message(ctx context.Context, message_hash string,
 		"updated_at":      time.Now(),
 	}).Error
 	if err != nil {
-		return fmt.Errorf("failed to update L2 message, id: %s, error: %v", message_hash, err)
+		return fmt.Errorf("failed to update L1 message, id: %s, error: %v", message_hash, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Updated misleading error log in UpdateL1Message from "failed to update L2 message"  ----> "failed to update L1 message".